### PR TITLE
Include an option to compute coordination metrics when CIF and CifEnsemble are initialized.

### DIFF
--- a/news/cifensemble-compute-cn.rst
+++ b/news/cifensemble-compute-cn.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Include an option to compute coordination metrics when CIF and CifEnsemble are initialized.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/cifkit/models/cif.py
+++ b/src/cifkit/models/cif.py
@@ -88,6 +88,7 @@ class Cif:
         is_formatted=False,
         logging_enabled=False,
         supercell_size=3,
+        compute_CN=False,
     ) -> None:
         """Initialize an object from a .cif file.
 
@@ -95,19 +96,19 @@ class Cif:
         ----------
         file_path : str
             Path to the .cif file.
-        is_formatted : bool, optional
+        is_formatted : bool, default
             If False, preprocess the .cif file to ensure compatibility with the
-            gemmi library. Default is False.
-        logging_enabled : bool, optional
+            gemmi library./
+        logging_enabled : bool, default False
             Enables detailed logging during initialization and for distance
             calculations. Default is False.
-        compute_CN : bool=True
-            If True, computes coordination numbers (CN) and related metrics.
-        supercell_size : int, optional
+        supercell_size : int, default 3
             Size of the supercell to be generated. Default is 3.
             Method 1 - No shifts
             Method 2 - ±1 shifts  (3x3x3 of the unit cell)
             Method 3 - ±2 shifts (5×5×5 of the unit cell)
+        compute_CN : bool, default False
+            Option to compute CN related metrics for each Cif object.
 
         Attributes
         ----------
@@ -189,7 +190,6 @@ class Cif:
 
         self.file_path = file_path
         self.logging_enabled = logging_enabled
-
         # Initialize the Cif object with the file path.
         self.file_name = os.path.basename(file_path)
         self.file_name_without_ext = os.path.splitext(self.file_name)[0]
@@ -201,6 +201,8 @@ class Cif:
         if not is_formatted:
             self._preprocess()
         self._load_data(supercell_size)
+        if compute_CN:
+            self.compute_CN()
 
     def _log_info(self, message):
         """Log a formatted message if logging is enabled."""
@@ -329,6 +331,7 @@ class Cif:
         """
 
         # CN max gap per site
+        print("We are computing CN")
         self._CN_max_gap_per_site = compute_CN_max_gap_per_site(
             self.radius_sum,
             self.connections,

--- a/src/cifkit/models/cif.py
+++ b/src/cifkit/models/cif.py
@@ -98,10 +98,10 @@ class Cif:
             Path to the .cif file.
         is_formatted : bool, default
             If False, preprocess the .cif file to ensure compatibility with the
-            gemmi library./
+            gemmi library.
         logging_enabled : bool, default False
             Enables detailed logging during initialization and for distance
-            calculations. Default is False.
+            calculations.
         supercell_size : int, default 3
             Size of the supercell to be generated. Default is 3.
             Method 1 - No shifts

--- a/src/cifkit/models/cif_ensemble.py
+++ b/src/cifkit/models/cif_ensemble.py
@@ -17,6 +17,7 @@ class CifEnsemble:
         preprocess=True,
         logging_enabled=False,
         supercell_size=3,
+        compute_CN=False,
     ) -> None:
         """Initialize a CifEnsemble object, containing a collection of
         Cif objects.
@@ -38,6 +39,8 @@ class CifEnsemble:
             format requiring manual modifications. It also relocates any ill-formatted
             files, such as those with duplicate labels in atom_site_label, missing
             fractional coordinates, or files requiring supercell generation.
+        compute_CN : bool, default False
+            Option to compute coordination numbers for each Cif object.
 
         logging_enabled : bool, optional
             Option to log while pre-processing Cif objects, by default False
@@ -74,18 +77,19 @@ class CifEnsemble:
         print(f"Initializing {self.file_count} Cif objects...")
 
         if logging_enabled:
-            self.cifs: list[Cif] = [
+            self.cifs = [
                 Cif(
                     file_path,
                     is_formatted=True,
                     logging_enabled=True,
                     supercell_size=supercell_size,
+                    compute_CN=compute_CN,
                 )
                 for file_path in self.file_paths
             ]
         else:
-            self.cifs: list[Cif] = [
-                Cif(file_path, is_formatted=True, supercell_size=supercell_size)
+            self.cifs = [
+                Cif(file_path, is_formatted=True, supercell_size=supercell_size, compute_CN=compute_CN)
                 for file_path in self.file_paths
             ]
         print("Finished initialization!")

--- a/src/cifkit/models/cif_ensemble.py
+++ b/src/cifkit/models/cif_ensemble.py
@@ -89,7 +89,12 @@ class CifEnsemble:
             ]
         else:
             self.cifs = [
-                Cif(file_path, is_formatted=True, supercell_size=supercell_size, compute_CN=compute_CN)
+                Cif(
+                    file_path,
+                    is_formatted=True,
+                    supercell_size=supercell_size,
+                    compute_CN=compute_CN,
+                )
                 for file_path in self.file_paths
             ]
         print("Finished initialization!")

--- a/tests/core/models/test_cif.py
+++ b/tests/core/models/test_cif.py
@@ -543,7 +543,23 @@ def test_plot_polyhedron_with_output_folder_given(cif_URhIn):
 
 
 """
-Test error during init
+Test init
+"""
+
+
+def test_init_cif_with_CN_computed():
+    file_path = "tests/data/cif/URhIn.cif"
+    cif = Cif(file_path, compute_CN=True, supercell_size=2)
+    assert cif.CN_bond_count_by_best_methods == {
+        "In1": {("In", "Rh"): 4, ("In", "U"): 6, ("In", "In"): 4},
+        "U1": {("Rh", "U"): 5, ("In", "U"): 6, ("U", "U"): 6},
+        "Rh1": {("In", "Rh"): 3, ("Rh", "U"): 6},
+        "Rh2": {("In", "Rh"): 6, ("Rh", "U"): 3},
+    }
+
+
+"""
+Test init error
 """
 
 


### PR DESCRIPTION

### What problem does this PR address?

Closes https://github.com/bobleesj/cifkit/issues/37

```python
"""
Test init
"""


def test_init_cif_with_CN_computed():
    file_path = "tests/data/cif/URhIn.cif"
    cif = Cif(file_path, compute_CN=True, supercell_size=2)
    assert cif.CN_bond_count_by_best_methods == {
        "In1": {("In", "Rh"): 4, ("In", "U"): 6, ("In", "In"): 4},
        "U1": {("Rh", "U"): 5, ("In", "U"): 6, ("U", "U"): 6},
        "Rh1": {("In", "Rh"): 3, ("Rh", "U"): 6},
        "Rh2": {("In", "Rh"): 6, ("Rh", "U"): 3},
    }
```

Now, you can optionally compute `CN` metrics when they are initialized.