### PR TITLE
Fixes issue where atoms go outside of unit cell boundaries and added …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,4 +178,3 @@ Acknowledgements
 
 ``cifkit`` is maintained and developed with the help of
 ``scikit-package`` (https://scikit-package.github.io/scikit-package/).
-

--- a/src/cifkit/models/cif.py
+++ b/src/cifkit/models/cif.py
@@ -275,37 +275,40 @@ class Cif:
         # Method implementation goes here
         self.unitcell_points = get_supercell_points(self._block, 1)
         self.supercell_points = get_supercell_points(self._block, supercell_size)
-        self.unitcell_points_for_plotting = self._generate_points_for_plotting(self.unitcell_points)
-        self.supercell_points_for_plotting = self._generate_points_for_plotting(self.supercell_points)
+        self.unitcell_points_for_plotting = self._generate_points_for_plotting(
+            self.unitcell_points
+        )
+        self.supercell_points_for_plotting = self._generate_points_for_plotting(
+            self.supercell_points
+        )
         self.unitcell_atom_count = get_cell_atom_count(self.unitcell_points)
         self.supercell_atom_count = get_cell_atom_count(self.supercell_points)
 
     def _generate_points_for_plotting(self, points, tolerance=1e-6):
+        """Generate coordinate points for visualization with boundary
+        handling.
 
-        """Generate coordinate points for visualization with boundary handling.
-    
-            This private helper method processes atom coordinates to ensure atoms
-            at unit cell boundaries appear on all equivalent faces for proper
-            visualization. Atoms with fractional coordinates at 0 or 1 (within
-            tolerance) are duplicated on opposite boundaries.
+        This private helper method processes atom coordinates to ensure atoms
+        at unit cell boundaries appear on all equivalent faces for proper
+        visualization. Atoms with fractional coordinates at 0 or 1 (within
+        tolerance) are duplicated on opposite boundaries.
 
-            Parameters
-            ----------
-            points : list[list[tuple[float, float, float, str]]]
-                List of atom points where each point contains fractional coordinates
-                (x, y, z) and a site label.
-            tolerance : float, default=1e-6
-                Threshold for detecting boundary atoms. Coordinates within this
-                tolerance of 0 or 1 are considered to be at the boundary.
+        Parameters
+        ----------
+        points : list[list[tuple[float, float, float, str]]]
+            List of atom points where each point contains fractional coordinates
+            (x, y, z) and a site label.
+        tolerance : float, default=1e-6
+            Threshold for detecting boundary atoms. Coordinates within this
+            tolerance of 0 or 1 are considered to be at the boundary.
 
-            Returns
-            -------
-            list[list[tuple[float, float, float, str]]]
-                Processed list of points with boundary atoms duplicated. Each point
-                is a tuple containing rounded fractional coordinates and site label.
-                Corner atoms (0,0,0) will appear at all 8 corners, edge atoms on all
-                corresponding edges, and face atoms on all corresponding faces.
-
+        Returns
+        -------
+        list[list[tuple[float, float, float, str]]]
+            Processed list of points with boundary atoms duplicated. Each point
+            is a tuple containing rounded fractional coordinates and site label.
+            Corner atoms (0,0,0) will appear at all 8 corners, edge atoms on all
+            corresponding edges, and face atoms on all corresponding faces.
         """
 
         all_coords = set()
@@ -317,11 +320,11 @@ class Cif:
             x_vals = [new_x, 1.0 - new_x] if abs(new_x) < tolerance else [new_x]
             if abs(new_x - 1.0) < tolerance:
                 x_vals.append(0.0)
-                
+
             y_vals = [new_y, 1.0 - new_y] if abs(new_y) < tolerance else [new_y]
             if abs(new_y - 1.0) < tolerance:
                 y_vals.append(0.0)
-                
+
             z_vals = [new_z, 1.0 - new_z] if abs(new_z) < tolerance else [new_z]
             if abs(new_z - 1.0) < tolerance:
                 z_vals.append(0.0)
@@ -330,7 +333,7 @@ class Cif:
             for dx in x_vals:
                 for dy in y_vals:
                     for dz in z_vals:
-                        coord = ((dx, dy, dz))
+                        coord = (dx, dy, dz)
                         coords_list.append(coord)
 
             for coord in coords_list:
@@ -344,7 +347,6 @@ class Cif:
                 )
 
         return list(all_coords)
-
 
     def compute_connections(self, cutoff_radius=10.0) -> None:
         """Compute onnection network, shortest distances, bond counts,

--- a/src/cifkit/models/cif.py
+++ b/src/cifkit/models/cif.py
@@ -275,8 +275,76 @@ class Cif:
         # Method implementation goes here
         self.unitcell_points = get_supercell_points(self._block, 1)
         self.supercell_points = get_supercell_points(self._block, supercell_size)
+        self.unitcell_points_for_plotting = self._generate_points_for_plotting(self.unitcell_points)
+        self.supercell_points_for_plotting = self._generate_points_for_plotting(self.supercell_points)
         self.unitcell_atom_count = get_cell_atom_count(self.unitcell_points)
         self.supercell_atom_count = get_cell_atom_count(self.supercell_points)
+
+    def _generate_points_for_plotting(self, points, tolerance=1e-6):
+
+        """Generate coordinate points for visualization with boundary handling.
+    
+            This private helper method processes atom coordinates to ensure atoms
+            at unit cell boundaries appear on all equivalent faces for proper
+            visualization. Atoms with fractional coordinates at 0 or 1 (within
+            tolerance) are duplicated on opposite boundaries.
+
+            Parameters
+            ----------
+            points : list[list[tuple[float, float, float, str]]]
+                List of atom points where each point contains fractional coordinates
+                (x, y, z) and a site label.
+            tolerance : float, default=1e-6
+                Threshold for detecting boundary atoms. Coordinates within this
+                tolerance of 0 or 1 are considered to be at the boundary.
+
+            Returns
+            -------
+            list[list[tuple[float, float, float, str]]]
+                Processed list of points with boundary atoms duplicated. Each point
+                is a tuple containing rounded fractional coordinates and site label.
+                Corner atoms (0,0,0) will appear at all 8 corners, edge atoms on all
+                corresponding edges, and face atoms on all corresponding faces.
+
+        """
+
+        all_coords = set()
+        for point in points:
+            new_x, new_y, new_z, atom_site_label = point
+
+            coords_list = []
+            # Build list of possible values for each dimension
+            x_vals = [new_x, 1.0 - new_x] if abs(new_x) < tolerance else [new_x]
+            if abs(new_x - 1.0) < tolerance:
+                x_vals.append(0.0)
+                
+            y_vals = [new_y, 1.0 - new_y] if abs(new_y) < tolerance else [new_y]
+            if abs(new_y - 1.0) < tolerance:
+                y_vals.append(0.0)
+                
+            z_vals = [new_z, 1.0 - new_z] if abs(new_z) < tolerance else [new_z]
+            if abs(new_z - 1.0) < tolerance:
+                z_vals.append(0.0)
+
+            # Generate all combinations
+            for dx in x_vals:
+                for dy in y_vals:
+                    for dz in z_vals:
+                        coord = ((dx, dy, dz))
+                        coords_list.append(coord)
+
+            for coord in coords_list:
+                all_coords.add(
+                    (
+                        round(coord[0], 5),
+                        round(coord[1], 5),
+                        round(coord[2], 5),
+                        atom_site_label,
+                    )
+                )
+
+        return list(all_coords)
+
 
     def compute_connections(self, cutoff_radius=10.0) -> None:
         """Compute onnection network, shortest distances, bond counts,

--- a/src/cifkit/preprocessors/supercell.py
+++ b/src/cifkit/preprocessors/supercell.py
@@ -93,6 +93,10 @@ def get_unitcell_coords_after_sym_operations_per_label(
                     ]
                 )
 
+                new_x = new_x % 1
+                new_y = new_y % 1
+                new_z = new_z % 1
+
                 all_coords.add(
                     (
                         round(new_x, 5),


### PR DESCRIPTION
Added boundary handling for unit cell and function to generate unit cell and super cell atoms for plotting.

- Add unitcell_points_for_plotting and supercell_points_for_plotting attributes to Cif class
- Implemented _generate_points_for_plotting() method to handle boundary atom duplication
- Atoms at coordinates 0 or 1 are now duplicated on opposite boundaries for proper visualization
- Corner atoms (0,0,0) appear at all 8 corners, edge atoms on all corresponding edges
- Modified supercell.py to process all labels for point generation
- Apply modulo operations in symmetry operation results for coordinate wrapping
