### PR TITLE
chore: update maintainer email to stanford address

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,7 +1,7 @@
 Authors
 =======
 
-Sangjoon Lee (bobleesj@gmail.com)
+Sangjoon Lee (bobleesj@stanford.edu)
 Anton Oliynyk (anton.oliynyk@hunter.cuny.edu)
 
 Contributors

--- a/CODE-OF-CONDUCT.rst
+++ b/CODE-OF-CONDUCT.rst
@@ -67,7 +67,7 @@ Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-bobleesj@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+bobleesj@stanford.edu. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/news/update-email.rst
+++ b/news/update-email.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Update the maintainer contact email to the Stanford address in package metadata, AUTHORS, and the code of conduct.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "cifkit"
 dynamic=['version', 'dependencies']
 authors = [
-  { name="Sangjoon Lee", email="bobleesj@gmail.com" },
+  { name="Sangjoon Lee", email="bobleesj@stanford.edu" },
 ]
 maintainers = [
-  { name="Sangjoon Lee", email="bobleesj@gmail.com" },
+  { name="Sangjoon Lee", email="bobleesj@stanford.edu" },
 ]
 description = "A Python package for coordination geometry and atomic site analysis."
 keywords = ['cif', 'solid-state', 'high-throughput', 'inorganics', 'crystallography']


### PR DESCRIPTION
### What problem does this PR address?

Closes #29

The new school email is active, so this replaces `bobleesj@gmail.com` with `bobleesj@stanford.edu` in `pyproject.toml` (authors + maintainers), `AUTHORS.rst`, and `CODE-OF-CONDUCT.rst` - the only three files carrying the contact address.

### What should the reviewer(s) do?

Merge before the 1.2.0 tag so the release metadata carries the new address.