### PR TITLE
chore: support Python 3.12-3.14, drop 3.11

### DIFF
--- a/news/python-3.12-3.14.rst
+++ b/news/python-3.12-3.14.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Drop Python 3.11 support; require Python 3.12--3.14 (classifiers and ``requires-python``).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "A Python package for coordination geometry and atomic site analysis."
 keywords = ['cif', 'solid-state', 'high-throughput', 'inorganics', 'crystallography']
 readme = "README.rst"
-requires-python = ">=3.11, <3.14"
+requires-python = ">=3.12, <3.15"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -25,9 +25,9 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]


### PR DESCRIPTION
### What problem does this PR address?

Align supported Python versions with the scikit-package default matrix (3.12–3.14). Drop 3.11. Update `requires-python` to `>=3.12, <3.15` and classifiers accordingly so release-scripts matrix CI picks up the right versions.

### What should the reviewer(s) do?

Merge. After merge, cut a small PyPI release so dependents can install on 3.14 without `--ignore-requires-python`.